### PR TITLE
fix: copy existing d.ts to build folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "@overmindtech/sdp-js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Javascript and Typescript libraries for the State Description Protocol",
   "types": "./lib/cjs/types/index.d.ts",
   "main": "./lib/cjs/index.js",
+  "exports": {
+    ".": "./lib/cjs/index.js"
+  },
   "scripts": {
     "clean": "rm -rf ./lib",
     "build": "npm run clean && npm run build:cjs",
@@ -17,8 +20,9 @@
     "typecheck:cjs": "tsc -p ./tsconfig.cjs.json --noEmit",
     "typecheck": "npm run typecheck:esm && npm run typecheck:cjs",
     "prettier:check": "prettier ./src --check",
-    "minify-pb-files": "npx uglify-js --compress --in-situ `find lib/cjs/__generated__ -type f -name '*.js'`",
-    "postbuild": "npm run minify-pb-files",
+    "minify-pb-files": "npx uglify-js --compress --in-situ `find lib/cjs/__generated__/ -type f -name '*.js'`",
+    "copy-declaration-files": "cp ./src/__generated__/*.d.ts ./lib/cjs/types/__generated__/",
+    "postbuild": "npm run minify-pb-files && npm run copy-declaration-files",
     "semantic-release": "semantic-release"
   },
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,19 @@ export * from './GatewaySession'
 export * from './RequestProgress'
 export * from './Responder'
 export * from './Util'
+export {
+  CancelItemRequest,
+  Edge,
+  GatewayRequest,
+  GatewayRequestStatus,
+  GatewayResponse,
+  Item,
+  ItemAttributes,
+  ItemRequest,
+  ItemRequestError,
+  Metadata,
+  Reference,
+  RequestMethod,
+  ResponderState,
+  Response,
+} from './__generated__/'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,9 +7,9 @@
     "checkJs": true,
     "allowJs": true,
     "declaration": true,
-    "declarationMap": true,
+    "declarationMap": false,
     "allowSyntheticDefaultImports": true
   },
   "files": ["./src/index.ts"],
-  "include": ["./src/__generated__"]
+  "include": ["./src/__generated__/"]
 }


### PR DESCRIPTION
Fixes a bug where the existing declaration files for protobuf would be overwritten during the tsc compile phase.