### PR TITLE
ci: update node and pnpm version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: pnpm/action-setup@v2
         id: pnpm-install
         with:
-          version: 8
+          version: 9
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 19
+          node-version: 20
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 19
+          node-version: 20
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         uses: pnpm/action-setup@v2
         id: pnpm-install
         with:
-          version: 8
+          version: 9
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 19
+          node-version: 20
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
I believe the version mismatch between local (pnpm v9) and CI(pnpm v8) causes pnpm to ignore the specified version of typescript we want which causes a lot of typescript errors [during CI.](https://github.com/overmindtech/sdp-js/actions/runs/12084274812)

local: typescript 5.6.3
ci: typescript 5.7.2
<img width="512" alt="Screenshot 2024-11-29 at 13 00 23" src="https://github.com/user-attachments/assets/9efadb9c-2f68-41c0-9ebd-a25992e9f698">

This fixes #221 and also aligns the versions with what is used in the frontend repo. 
