### PR TITLE
chore: remove common js support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overmindtech/sdp-js",
-  "version": "12.2.0",
+  "version": "13.0.0",
   "description": "Javascript and Typescript libraries for the State Description Protocol",
   "license": "MIT",
   "sideEffects": false,
@@ -8,11 +8,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.mjs"
     }
   },
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [


### PR DESCRIPTION
This is a breaking change.

Once https://github.com/overmindtech/frontend/pull/1654 is merged. The frontend will no longer need cjs support. The app itself wasn't using the cjs version but Jest was and isn't great with modules and requires a bit more configuration compared to Vitest.