### PR TITLE
Revert "chore: remove common js support (#232)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.mjs",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [


### PR DESCRIPTION
This reverts commit 568c7917dafa7a0b38dd8a61ca37a74f55126fd4.

common js support is still required for Auth0 Actions.